### PR TITLE
fix: 手机端列表标题换行

### DIFF
--- a/src/app/_components/home/ArticleCard.tsx
+++ b/src/app/_components/home/ArticleCard.tsx
@@ -35,7 +35,7 @@ export function ArticleCard({ article, index }: ArticleCardProps) {
           </div>
 
           {/* 标题 */}
-          <h3 className='text-fg-default group-hover:text-fg-accent relative mb-auto line-clamp-3 text-xl leading-relaxed font-semibold transition-colors duration-200'>
+          <h3 className='text-fg-default group-hover:text-fg-accent relative mb-auto line-clamp-3 text-lg leading-relaxed font-semibold transition-colors duration-200 sm:text-xl'>
             {article.title}
           </h3>
 


### PR DESCRIPTION
Closes #36

Patch generated by `poolside/laguna-s-2.1:free` via OpenRouter.